### PR TITLE
flatpak: Re-order modules and fix pandoc build

### DIFF
--- a/flatpak/uberwriter.json
+++ b/flatpak/uberwriter.json
@@ -32,29 +32,13 @@
     },
     "modules": [
         {
-        "name": "uberwriter",
-        "sources": [
-                {
-                    "type" : "git",
-                    "url" : "git://github.com/wolfv/uberwriter",
-                    "branch" : "master"
-                }
-            ],
-            "build-commands": [
-                "install -Dm644 flatpak/de.wolfvollprecht.UberWriter.appdata.xml /app/share/appdata/de.wolfvollprecht.UberWriter.appdata.xml "
-            ],
-            "post-install": [
-            "glib-compile-schemas /app/share/glib-2.0/schemas",
-            "install -d /app/extensions"
-            ]
-        },
-        {
         "name": "pandoc",
         "only-arches": [
           "x86_64"
             ],
         "buildsystem": "simple",
         "build-commands": [
+          "mkdir -p /app/bin/pandoc",
           "cp bin/pandoc /app/bin/pandoc",
           "cp bin/pandoc-citeproc /app/bin/pandoc-citeproc"
             ],
@@ -127,6 +111,23 @@
                     "type": "file",
                     "path": "de.wolfvollprecht.UberWriter.appdata.xml"
                 }
+            ]
+        },
+        {
+        "name": "uberwriter",
+        "sources": [
+                {
+                    "type" : "git",
+                    "url" : "git://github.com/wolfv/uberwriter",
+                    "branch" : "master"
+                }
+            ],
+            "build-commands": [
+                "install -Dm644 flatpak/de.wolfvollprecht.UberWriter.appdata.xml /app/share/appdata/de.wolfvollprecht.UberWriter.appdata.xml "
+            ],
+            "post-install": [
+            "glib-compile-schemas /app/share/glib-2.0/schemas",
+            "install -d /app/extensions"
             ]
         }
     ]


### PR DESCRIPTION
For flatpaks the last module should usually be the application being
installed. In this case, uberwriter. In addition, the build process
for pandoc made an assumption that /app/bin would be present after
building the uberwriter module, but since that wasn't the case /app/bin/pandoc
must be created in advance.

Fixes issues where the flatpak build wouldn't run due to "missing" python modules.