### PR TITLE
Menu.ui: Use GNOME HIG for Primary Menu

### DIFF
--- a/data/ui/Menu.ui
+++ b/data/ui/Menu.ui
@@ -35,12 +35,6 @@
         </section>
         <section>
             <item>
-                <attribute name="label" translatable="yes">Preferences</attribute>
-                <attribute name="action">app.preferences</attribute>
-            </item>
-        </section>
-        <section>
-            <item>
                 <attribute name="label" translatable="yes">Open Tutorial</attribute>
                 <attribute name="action">app.open_examples</attribute>
             </item>
@@ -48,19 +42,19 @@
                 <attribute name="action">app.help</attribute>
                 <attribute name="label" translatable="yes">Pandoc _Help</attribute>
             </item>
-            <item>
-                <attribute name="action">app.shortcuts</attribute>
-                <attribute name="label" translatable="yes">_Shortcuts</attribute>
-            </item>
         </section>
         <section>
             <item>
-                <attribute name="action">app.about</attribute>
-                <attribute name="label" translatable="yes">_About</attribute>
+                <attribute name="label" translatable="yes">Preferences</attribute>
+                <attribute name="action">app.preferences</attribute>
             </item>
             <item>
-                <attribute name="label" translatable="yes">_Quit</attribute>
-                <attribute name="action">app.quit</attribute>
+                <attribute name="action">app.shortcuts</attribute>
+                <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+            </item>
+            <item>
+                <attribute name="action">app.about</attribute>
+                <attribute name="label" translatable="yes">_About UberWriter</attribute>
             </item>
         </section>
     </menu>


### PR DESCRIPTION
As per https://gitlab.gnome.org/GNOME/Initiatives/wikis/App-Menu-Retirement,
the new HIG has a few requirements:

* About should be "About <Application Name>"
* Preferences should be in the same section as About and Keyboard Shortcuts
* Shortcuts should be Keyboard Shortcuts
* Quit should be removed, as it's redundant