### PR TITLE
Statistics

### DIFF
--- a/data/de.wolfvollprecht.UberWriter.gschema.xml
+++ b/data/de.wolfvollprecht.UberWriter.gschema.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <schemalist>
+  <enum id='de.wolfvollprecht.UberWriter.Stat'>
+    <value nick='characters' value='0' />
+    <value nick='words' value='1' />
+    <value nick='sentences' value='2' />
+    <value nick='read_time' value='3' />
+  </enum>
+
 
   <schema path="/de/wolfvollprecht/UberWriter/" id="de.wolfvollprecht.UberWriter">
 
@@ -52,6 +59,13 @@
       <summary>Open file base path</summary>
       <description>
         Open file paths of the current session
+      </description>
+    </key>
+    <key name='stat-default' enum='de.wolfvollprecht.UberWriter.Stat'>
+      <default>"words"</default>
+      <summary>Default statistic</summary>
+      <description>
+        Which statistic is shown on the main window.
       </description>
     </key>
 

--- a/data/de.wolfvollprecht.UberWriter.gschema.xml
+++ b/data/de.wolfvollprecht.UberWriter.gschema.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <schemalist>
+
   <enum id='de.wolfvollprecht.UberWriter.Stat'>
     <value nick='characters' value='0' />
     <value nick='words' value='1' />
     <value nick='sentences' value='2' />
-    <value nick='read_time' value='3' />
+    <value nick='paragraphs' value='3' />
+    <value nick='read_time' value='4' />
   </enum>
-
 
   <schema path="/de/wolfvollprecht/UberWriter/" id="de.wolfvollprecht.UberWriter">
 

--- a/data/media/css/_gtk_base.css
+++ b/data/media/css/_gtk_base.css
@@ -86,15 +86,10 @@
 }
 
 
-.status-bar-box label {
-  color: #666;
-}
-
-.status-bar-box button {
-  /* finding reset */
+.stats-counter {
+  color: alpha(@foreground_color, 0.6);
   background-color: @background_color;
   text-shadow: inherit;
-  /*icon-shadow: inherit;*/
   box-shadow: initial;
   background-clip: initial;
   background-origin: initial;
@@ -106,37 +101,15 @@
   border-image-repeat: initial;
   border-image-slice: initial;
   border-image-width: initial;
-
   border-style: none;
-  -button-images: true;
-  border-radius: 2px;
-  color: #666;
-  padding: 3px 5px;
+  padding: 0px 16px;
   transition: 100ms ease-in;
 }
 
-.status-bar-box button:hover,
-.status-bar-box button:checked {
-  transition: 0s ease-in;
-  color: @background_color;
-  background-color: #666;
-}
-
-.status-bar-box button:hover label,
-.status-bar-box button:checked label {
-  color: @background_color;
-}
-
-.status-bar-box button:active {
-  color: #EEE;
-  background-color: #EEE;
-  background-image: none;
-  box-shadow: 0 0 2px rgba(0,0,0,0.4)
-}
-
-.status-bar-box separator {
-  border-color: #999;
-  border-right: none;
+.stats-counter:hover,
+.stats-counter:checked {
+  color: @foreground_color;
+  background-color: lighter(@background_color);
 }
 
 #PreviewMenuItem image {

--- a/data/ui/Window.ui
+++ b/data/ui/Window.ui
@@ -75,97 +75,20 @@
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
                 <child>
-                  <object class="GtkRevealer" id="status_bar_revealer">
+                  <object class="GtkRevealer" id="stats_counter_revealer">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="transition_type">crossfade</property>
                     <property name="transition_duration">750</property>
                     <property name="reveal_child">True</property>
                     <child>
-                      <object class="GtkGrid" id="status_bar_box">
+                      <object class="GtkButton" id="stats_counter">
+                        <property name="label" translatable="yes">0 Words</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="label2">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Words:</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">3</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="word_count">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label">0</property>
-                            <property name="justify">right</property>
-                            <property name="width_chars">4</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">4</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator" id="separator1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="margin_left">10</property>
-                            <property name="margin_right">10</property>
-                            <property name="margin_start">10</property>
-                            <property name="margin_end">10</property>
-                            <property name="orientation">vertical</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">5</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Characters:</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">6</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="char_count">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="margin_right">11</property>
-                            <property name="margin_end">11</property>
-                            <property name="label">0</property>
-                            <property name="width_chars">6</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">7</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Show Statistics</property>
+                        <property name="halign">end</property>
                       </object>
                     </child>
                   </object>

--- a/uberwriter/application.py
+++ b/uberwriter/application.py
@@ -40,6 +40,8 @@ class Application(Gtk.Application):
 
         self.settings.connect("changed", self.on_settings_changed)
 
+        # Header bar
+
         action = Gio.SimpleAction.new("new", None)
         action.connect("activate", self.on_new)
         self.add_action(action)
@@ -59,6 +61,8 @@ class Application(Gtk.Application):
         action = Gio.SimpleAction.new("search", None)
         action.connect("activate", self.on_search)
         self.add_action(action)
+
+        # App Menu
 
         action = Gio.SimpleAction.new_stateful(
             "focus_mode", None, GLib.Variant.new_boolean(False))
@@ -110,6 +114,14 @@ class Application(Gtk.Application):
 
         action = Gio.SimpleAction.new("quit", None)
         action.connect("activate", self.on_quit)
+        self.add_action(action)
+
+        # Stats Menu
+
+        stat_default = self.settings.get_string("stat-default")
+        action = Gio.SimpleAction.new_stateful(
+            "stat_default", GLib.VariantType.new('s'), GLib.Variant.new_string(stat_default))
+        action.connect("activate", self.on_stat_default)
         self.add_action(action)
 
         # Shortcuts
@@ -166,6 +178,8 @@ class Application(Gtk.Application):
             self.window.toggle_gradient_overlay(settings.get_value(key))
         elif key == "input-format":
             self.window.reload_preview()
+        elif key == "stat-default":
+            self.window.update_default_stat()
 
     def on_new(self, _action, _value):
         self.window.new_document()
@@ -231,6 +245,10 @@ class Application(Gtk.Application):
 
     def on_quit(self, _action, _param):
         self.quit()
+
+    def on_stat_default(self, action, value):
+        action.set_state(value)
+        self.settings.set_string("stat-default", value.get_string())
 
 # ~ if __name__ == "__main__":
     # ~ app = Application()

--- a/uberwriter/stats_counter.py
+++ b/uberwriter/stats_counter.py
@@ -22,6 +22,9 @@ class StatsCounter:
     # exclamation mark, paragraph, and variants.
     SENTENCES = re.compile(r"[^\n][.。।෴۔።?՞;⸮؟？፧꘏⳺⳻⁇﹖⁈⁉‽!﹗！՜߹႟᥄\n]+")
 
+    # Regexp that matches paragraphs, ie. anything separated by newlines.
+    PARAGRAPHS = re.compile(r".+\n?")
+
     def __init__(self):
         super().__init__()
 
@@ -61,8 +64,12 @@ class StatsCounter:
 
             sentence_count = len(re.findall(self.SENTENCES, text))
 
+            paragraph_count = len(re.findall(self.PARAGRAPHS, text))
+
             read_m, read_s = divmod(word_count / 200 * 60, 60)
             read_h, read_m = divmod(read_m, 60)
             read_time = (int(read_h), int(read_m), int(read_s))
 
-            GLib.idle_add(callback, (character_count, word_count, sentence_count, read_time))
+            GLib.idle_add(
+                callback,
+                (character_count, word_count, sentence_count, paragraph_count, read_time))

--- a/uberwriter/stats_counter.py
+++ b/uberwriter/stats_counter.py
@@ -9,7 +9,7 @@ from uberwriter import helpers
 
 
 class StatsCounter:
-    """Counts characters, words, sentences and reading time using a background thread."""
+    """Counts characters, words, sentences and read time using a background thread."""
 
     # Regexp that matches any character, except for newlines and subsequent spaces.
     CHARACTERS = re.compile(r"[^\s]|(?:[^\S\n](?!\s))")
@@ -26,11 +26,11 @@ class StatsCounter:
         super().__init__()
 
         self.queue = Queue()
-        worker = Thread(target=self.__do_count_stats, name="stats-counter")
+        worker = Thread(target=self.__do_count, name="stats-counter")
         worker.daemon = True
         worker.start()
 
-    def count_stats(self, text, callback):
+    def count(self, text, callback):
         """Count stats for text, calling callback with a result when done.
 
         The callback argument contains the result, in the form:
@@ -44,7 +44,7 @@ class StatsCounter:
 
         self.queue.put((None, None))
 
-    def __do_count_stats(self):
+    def __do_count(self):
         while True:
             while True:
                 (text, callback) = self.queue.get()
@@ -61,10 +61,8 @@ class StatsCounter:
 
             sentence_count = len(re.findall(self.SENTENCES, text))
 
-            dec_, int_ = math.modf(word_count / 200)
-            hours = int(int_ / 60)
-            minutes = int(int_ % 60)
-            seconds = round(dec_ * 0.6)
-            reading_time = (hours, minutes, seconds)
+            read_m, read_s = divmod(word_count / 200 * 60, 60)
+            read_h, read_m = divmod(read_m, 60)
+            read_time = (int(read_h), int(read_m), int(read_s))
 
-            GLib.idle_add(callback, (character_count, word_count, sentence_count, reading_time))
+            GLib.idle_add(callback, (character_count, word_count, sentence_count, read_time))

--- a/uberwriter/stats_counter.py
+++ b/uberwriter/stats_counter.py
@@ -1,0 +1,70 @@
+import math
+import re
+from queue import Queue
+from threading import Thread
+
+from gi.repository import GLib
+
+from uberwriter import helpers
+
+
+class StatsCounter:
+    """Counts characters, words, sentences and reading time using a background thread."""
+
+    # Regexp that matches any character, except for newlines and subsequent spaces.
+    CHARACTERS = re.compile(r"[^\s]|(?:[^\S\n](?!\s))")
+
+    # Regexp that matches Asian letters, general symbols and hieroglyphs,
+    # as well as sequences of word characters optionally containing non-word characters in-between.
+    WORDS = re.compile(r"[\u3040-\uffff]|(?:\w+\S?\w*)+", re.UNICODE)
+
+    # Regexp that matches sentence-ending punctuation characters, ie. full stop, question mark,
+    # exclamation mark, paragraph, and variants.
+    SENTENCES = re.compile(r"[^\n][.。।෴۔።?՞;⸮؟？፧꘏⳺⳻⁇﹖⁈⁉‽!﹗！՜߹႟᥄\n]+")
+
+    def __init__(self):
+        super().__init__()
+
+        self.queue = Queue()
+        worker = Thread(target=self.__do_count_stats, name="stats-counter")
+        worker.daemon = True
+        worker.start()
+
+    def count_stats(self, text, callback):
+        """Count stats for text, calling callback with a result when done.
+
+        The callback argument contains the result, in the form:
+
+        (characters, words, sentences, (hours, minutes, seconds))"""
+
+        self.queue.put((text, callback))
+
+    def stop(self):
+        """Stops the background worker. StatsCounter shouldn't be used after this."""
+
+        self.queue.put((None, None))
+
+    def __do_count_stats(self):
+        while True:
+            while True:
+                (text, callback) = self.queue.get()
+                if text is None and callback is None:
+                    return
+                if self.queue.empty():
+                    break
+
+            text = helpers.pandoc_convert(text, to="plain")
+
+            character_count = len(re.findall(self.CHARACTERS, text))
+
+            word_count = len(re.findall(self.WORDS, text))
+
+            sentence_count = len(re.findall(self.SENTENCES, text))
+
+            dec_, int_ = math.modf(word_count / 200)
+            hours = int(int_ / 60)
+            minutes = int(int_ % 60)
+            seconds = round(dec_ * 0.6)
+            reading_time = (hours, minutes, seconds)
+
+            GLib.idle_add(callback, (character_count, word_count, sentence_count, reading_time))

--- a/uberwriter/stats_handler.py
+++ b/uberwriter/stats_handler.py
@@ -30,6 +30,7 @@ class StatsHandler:
         self.characters = 0
         self.words = 0
         self.sentences = 0
+        self.paragraphs = 0
         self.read_time = (0, 0, 0)
 
         self.settings = Settings.new()
@@ -43,22 +44,11 @@ class StatsHandler:
         self.stats_button.set_state_flags(Gtk.StateFlags.CHECKED, False)
 
         menu = Gio.Menu()
-        characters_menu_item = Gio.MenuItem.new(self.get_text_for_stat(0), None)
-        characters_menu_item.set_action_and_target_value(
-            "app.stat_default", GLib.Variant.new_string("characters"))
-        menu.append_item(characters_menu_item)
-        words_menu_item = Gio.MenuItem.new(self.get_text_for_stat(1), None)
-        words_menu_item.set_action_and_target_value(
-            "app.stat_default", GLib.Variant.new_string("words"))
-        menu.append_item(words_menu_item)
-        sentences_menu_item = Gio.MenuItem.new(self.get_text_for_stat(2), None)
-        sentences_menu_item.set_action_and_target_value(
-            "app.stat_default", GLib.Variant.new_string("sentences"))
-        menu.append_item(sentences_menu_item)
-        read_time_menu_item = Gio.MenuItem.new(self.get_text_for_stat(3), None)
-        read_time_menu_item.set_action_and_target_value(
-            "app.stat_default", GLib.Variant.new_string("read_time"))
-        menu.append_item(read_time_menu_item)
+        stats = self.settings.props.settings_schema.get_key("stat-default").get_range()[1]
+        for i, stat in enumerate(stats):
+            menu_item = Gio.MenuItem.new(self.get_text_for_stat(i), None)
+            menu_item.set_action_and_target_value("app.stat_default", GLib.Variant.new_string(stat))
+            menu.append_item(menu_item)
         self.popover = Gtk.Popover.new_from_model(self.stats_button, menu)
         self.popover.connect('closed', self.on_popover_closed)
         self.popover.popup()
@@ -82,13 +72,18 @@ class StatsHandler:
         elif stat == 2:
             return _("{:n} Sentences".format(self.sentences))
         elif stat == 3:
+            return _("{:n} Paragraphs".format(self.paragraphs))
+        elif stat == 4:
             return _("{:d}:{:02d}:{:02d} Read Time".format(*self.read_time))
+        else:
+            raise ValueError("Unknown stat {}".format(stat))
 
     def update_stats(self, stats):
-        (characters, words, sentences, read_time) = stats
+        (characters, words, sentences, paragraphs, read_time) = stats
         self.characters = characters
         self.words = words
         self.sentences = sentences
+        self.paragraphs = paragraphs
         self.read_time = read_time
         self.update_default_stat(False)
 

--- a/uberwriter/stats_handler.py
+++ b/uberwriter/stats_handler.py
@@ -1,0 +1,103 @@
+import math
+import re
+from gettext import gettext as _
+from queue import Queue
+from threading import Thread
+
+from gi.repository import GLib, Gio, Gtk
+
+from uberwriter import helpers
+from uberwriter.helpers import get_builder
+from uberwriter.settings import Settings
+from uberwriter.stats_counter import StatsCounter
+
+
+class StatsHandler:
+    """Shows a default statistic on the stats button, and allows the user to toggle which one."""
+
+    def __init__(self, stats_button, text_view):
+        super().__init__()
+
+        self.stats_button = stats_button
+        self.stats_button.connect("clicked", self.on_stats_button_clicked)
+        self.stats_button.connect("destroy", self.on_destroy)
+
+        self.text_view = text_view
+        self.text_view.get_buffer().connect("changed", self.on_text_changed)
+
+        self.popover = None
+
+        self.characters = 0
+        self.words = 0
+        self.sentences = 0
+        self.read_time = (0, 0, 0)
+
+        self.settings = Settings.new()
+        self.default_stat = self.settings.get_enum("stat-default")
+
+        self.stats_counter = StatsCounter()
+
+        self.update_default_stat()
+
+    def on_stats_button_clicked(self, _button):
+        self.stats_button.set_state_flags(Gtk.StateFlags.CHECKED, False)
+
+        menu = Gio.Menu()
+        characters_menu_item = Gio.MenuItem.new(self.get_text_for_stat(0), None)
+        characters_menu_item.set_action_and_target_value(
+            "app.stat_default", GLib.Variant.new_string("characters"))
+        menu.append_item(characters_menu_item)
+        words_menu_item = Gio.MenuItem.new(self.get_text_for_stat(1), None)
+        words_menu_item.set_action_and_target_value(
+            "app.stat_default", GLib.Variant.new_string("words"))
+        menu.append_item(words_menu_item)
+        sentences_menu_item = Gio.MenuItem.new(self.get_text_for_stat(2), None)
+        sentences_menu_item.set_action_and_target_value(
+            "app.stat_default", GLib.Variant.new_string("sentences"))
+        menu.append_item(sentences_menu_item)
+        read_time_menu_item = Gio.MenuItem.new(self.get_text_for_stat(3), None)
+        read_time_menu_item.set_action_and_target_value(
+            "app.stat_default", GLib.Variant.new_string("read_time"))
+        menu.append_item(read_time_menu_item)
+        self.popover = Gtk.Popover.new_from_model(self.stats_button, menu)
+        self.popover.connect('closed', self.on_popover_closed)
+        self.popover.popup()
+
+    def on_popover_closed(self, _popover):
+        self.stats_button.unset_state_flags(Gtk.StateFlags.CHECKED)
+
+        self.popover = None
+        self.text_view.grab_focus()
+
+    def on_text_changed(self, buf):
+        self.stats_counter.count(
+            buf.get_text(buf.get_start_iter(), buf.get_end_iter(), False),
+            self.update_stats)
+
+    def get_text_for_stat(self, stat):
+        if stat == 0:
+            return _("{:n} Characters".format(self.characters))
+        elif stat == 1:
+            return _("{:n} Words".format(self.words))
+        elif stat == 2:
+            return _("{:n} Sentences".format(self.sentences))
+        elif stat == 3:
+            return _("{:d}:{:02d}:{:02d} Read Time".format(*self.read_time))
+
+    def update_stats(self, stats):
+        (characters, words, sentences, read_time) = stats
+        self.characters = characters
+        self.words = words
+        self.sentences = sentences
+        self.read_time = read_time
+        self.update_default_stat(False)
+
+    def update_default_stat(self, close_popover=True):
+        stat = self.settings.get_enum("stat-default")
+        text = self.get_text_for_stat(stat)
+        self.stats_button.set_label(text)
+        if close_popover and self.popover:
+            self.popover.popdown()
+
+    def on_destroy(self, _widget):
+        self.stats_counter.stop()


### PR DESCRIPTION
This PR improves statistics counting, as well as adds support for more of them, fixing #63. It does so in a iA Writer inspired way, meaning:
* The stats bar displays one stat, word count by default.
* The stats bar now contains a button that [displays all stats and allows toggling between them](https://cl.ly/a0ce3fad3d72/gnome-shell-screenshot-QRNG0Z.png).
* The default stat is saved between sessions.
* All the stats are objective and deterministic. For instance, I contemplated adding GhostWriter's "Pages" estimation, but it's outright broken in my testing, and I also think we should be strict about what too include. Too many things will make it less useful. Regardless, it's trivial to extend.
* Calculations are done on a worker thread, to prevent hogging the UI and allowing future extensibility without much consideration.