### PR TITLE
gitignore: Add generated folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ data/ui/shortcut_handlers
 *.glade~
 dist/uberwriter-2.0b0-py3.7.egg
 builddir/*
+dist/
+uberwriter.egg-info


### PR DESCRIPTION
These folders are not tracked by us and thus should be
ignored. Prevents them from accidentally being added.