### PR TITLE
Fix file paths

### DIFF
--- a/uberwriter/helpers.py
+++ b/uberwriter/helpers.py
@@ -55,7 +55,7 @@ def get_builder(builder_file_name):
 def path_to_file(path):
     """Return a file path (file:///) for the given path"""
 
-    return "file:///" + path
+    return "file://" + path
 
 
 def get_media_file(media_file_path):


### PR DESCRIPTION
`path_to_file`'s argument is an absolute path, which already contains a leading `/`. 

Having an additional slash (ie. `file:////some/path`) breaks some things, eg. the export flow using local assets.