### PR TITLE
Remove unused NUMERICLIST

### DIFF
--- a/uberwriter/text_view_markup_handler.py
+++ b/uberwriter/text_view_markup_handler.py
@@ -39,7 +39,6 @@ class MarkupHandler:
         "LINK": re.compile(r"(\[).*(\]\(.+?\))"),
         "HORIZONTALRULE": re.compile(r"\n\n([ ]{0,3}[*\-_]{3,}[ ]*)\n\n", re.MULTILINE),
         "LIST": re.compile(r"^((?:\t|[ ]{4})*)[\-*+] .+", re.MULTILINE),
-        "NUMERICLIST": re.compile(r"^((\d|[a-z]|#)+[.)]) ", re.MULTILINE),
         "NUMBEREDLIST": re.compile(r"^((?:\t|[ ]{4})*)((?:\d|[a-z])+[.)]) .+", re.MULTILINE),
         "BLOCKQUOTE": re.compile(r"^[ ]{0,3}(?:>|(?:> )+).+", re.MULTILINE),
         "HEADER": re.compile(r"^[ ]{0,3}(#{1,6}) [^\n]+", re.MULTILINE),


### PR DESCRIPTION
This is probably a left-over from earlier work on the markup parser.