### PR TITLE
Impove text rendering in bullets

### DIFF
--- a/uberwriter/markup_regex.py
+++ b/uberwriter/markup_regex.py
@@ -1,11 +1,11 @@
 import re
 
 ITALIC = re.compile(
-    r"(\*|_)(?P<text>.*?\S.*?)\1")
+    r"(\*|_)[^\s*](?P<text>.*?\S.*?)\1")
 BOLD = re.compile(
-    r"(\*\*|__)(?P<text>.*?\S.*?)\1")
+    r"(\*\*|__)[^\s*](?P<text>.*?\S.*?)\1")
 BOLD_ITALIC = re.compile(
-    r"((\*\*|__)([*_])|([*_])(\*\*|__))(?P<text>.*?\S.*?)(?:\5\4|\3\2)")
+    r"((\*\*|__)([*_])|([*_])(\*\*|__))[^\s*](?P<text>.*?\S.*?)(?:\5\4|\3\2)")
 STRIKETHROUGH = re.compile(
     r"~~(?P<text>.*?\S.*?)~~")
 CODE = re.compile(


### PR DESCRIPTION
Fixes the specific issue of #135 by not putting text in bold/italics if there if a space just after the * symbol(s).

It makes sense because pandoc doesn't make the text between asterisks bold or italic if the text starts with a space.