### PR TITLE
Improve emphasis behaviour

### DIFF
--- a/uberwriter/markup_regex.py
+++ b/uberwriter/markup_regex.py
@@ -1,7 +1,9 @@
 import re
 
-ITALIC = re.compile(
-    r"(\*|_)[^\s*](?P<text>.*?\S.*?)\1")
+ITALIC_ASTERISK = re.compile(
+    r"(?<!\\)\*[^\s\*](?P<text>.*?\S?.*?)(?<!\\)\*")
+ITALIC_UNDERSCORE = re.compile(
+    r"(?<!(\\|\S))_[^\s_](?P<text>.*?\S?.*?)(?<!\\)_(?=\s)")
 BOLD = re.compile(
     r"(\*\*|__)[^\s*](?P<text>.*?\S.*?)\1")
 BOLD_ITALIC = re.compile(

--- a/uberwriter/stats_counter.py
+++ b/uberwriter/stats_counter.py
@@ -3,7 +3,7 @@ from multiprocessing import Process, Pipe
 
 from gi.repository import GLib
 
-from uberwriter.markup_regex import ITALIC, BOLD_ITALIC, BOLD, STRIKETHROUGH, IMAGE, LINK, LINK_ALT,\
+from uberwriter.markup_regex import ITALIC_ASTERISK, ITALIC_UNDERSCORE, BOLD_ITALIC, BOLD, STRIKETHROUGH, IMAGE, LINK, LINK_ALT,\
     HORIZONTAL_RULE, LIST, MATH, TABLE, CODE_BLOCK, HEADER_UNDER, HEADER, BLOCK_QUOTE, ORDERED_LIST, \
     FOOTNOTE_ID, FOOTNOTE
 
@@ -27,7 +27,7 @@ class StatsCounter:
 
     # List of regexp whose matches should be replaced by their "text" group. Order is important.
     MARKUP_REGEXP_REPLACE = (
-        BOLD_ITALIC, ITALIC, BOLD, STRIKETHROUGH, IMAGE, LINK, LINK_ALT, LIST, ORDERED_LIST,
+        BOLD_ITALIC, ITALIC_ASTERISK, ITALIC_UNDERSCORE, BOLD, STRIKETHROUGH, IMAGE, LINK, LINK_ALT, LIST, ORDERED_LIST,
         BLOCK_QUOTE, HEADER, HEADER_UNDER, CODE_BLOCK, TABLE, MATH, FOOTNOTE_ID, FOOTNOTE
     )
 

--- a/uberwriter/text_view_markup_handler.py
+++ b/uberwriter/text_view_markup_handler.py
@@ -20,7 +20,7 @@ from multiprocessing import Pipe, Process
 import gi
 
 from uberwriter import helpers, markup_regex
-from uberwriter.markup_regex import STRIKETHROUGH, BOLD_ITALIC, BOLD, ITALIC, IMAGE, LINK,\
+from uberwriter.markup_regex import STRIKETHROUGH, BOLD_ITALIC, BOLD, ITALIC_ASTERISK, ITALIC_UNDERSCORE, IMAGE, LINK,\
     LINK_ALT, HORIZONTAL_RULE, LIST, ORDERED_LIST, BLOCK_QUOTE, HEADER, HEADER_UNDER, TABLE, MATH, \
     CODE
 
@@ -186,7 +186,8 @@ class MarkupHandler:
             # - "$math$" (colorize)
             # - "---" table (wrap/pixels)
             regexps = (
-                (ITALIC, self.TAG_NAME_ITALIC),
+                (ITALIC_ASTERISK, self.TAG_NAME_ITALIC),
+                (ITALIC_UNDERSCORE, self.TAG_NAME_ITALIC),
                 (BOLD, self.TAG_NAME_BOLD),
                 (BOLD_ITALIC, self.TAG_NAME_BOLD_ITALIC),
                 (STRIKETHROUGH, self.TAG_NAME_STRIKETHROUGH),


### PR DESCRIPTION
This PR makes the simple asterisks and underscore for emphasis follow Pandoc's markdown more closely. For example (from [Pandoc's Manual](https://pandoc.org/MANUAL.html#pandocs-markdown)):

- A * or _ character surrounded by spaces, or backslash-escaped, will not trigger emphasis.

- Because _ is sometimes used inside words and identifiers, pandoc does not interpret a _ surrounded by alphanumeric characters as an emphasis marker. If you want to emphasize just part of a word, use *: