### PR TITLE
Fix Shift-Tab Behaviour

### DIFF
--- a/uberwriter/text_view.py
+++ b/uberwriter/text_view.py
@@ -262,7 +262,9 @@ class TextView(Gtk.TextView):
         iter.backward_char()
 
         if iter.get_char() == "\t":
-            text_buffer.delete(iter, end)
+            with user_action(text_buffer):
+	            text_buffer.delete(iter, end)
+
 
     def clear(self):
         """Clear text and undo history"""

--- a/uberwriter/text_view.py
+++ b/uberwriter/text_view.py
@@ -255,10 +255,14 @@ class TextView(Gtk.TextView):
 
     def on_shift_tab(self):
         """Delete last character if it is a tab"""
+        text_buffer = self.get_buffer()
+        iter = text_buffer.get_end_iter()
+        end = text_buffer.get_end_iter()
 
-        text = self.get_text()
-        if text[-1] == "\t":
-            self.set_text(text[:-1])
+        iter.backward_char()
+
+        if iter.get_char() == "\t":
+            text_buffer.delete(iter, end)
 
     def clear(self):
         """Clear text and undo history"""

--- a/uberwriter/text_view.py
+++ b/uberwriter/text_view.py
@@ -110,7 +110,7 @@ class TextView(Gtk.TextView):
 
         # Hemingway mode
         self.hemingway_mode = False
-        self.connect('key-press-event', self.on_key_press_event)
+        self.connect('key-press-event', self._on_key_press_event)
 
         # While resizing the TextView, there is unwanted scroll upwards if a top margin is present.
         # When a size allocation is detected, this variable will hold the scroll to re-set until the
@@ -243,29 +243,6 @@ class TextView(Gtk.TextView):
 
         self.hemingway_mode = hemingway_mode
 
-    def on_key_press_event(self, _widget, event):
-        if self.hemingway_mode:
-            return event.keyval == Gdk.KEY_BackSpace or event.keyval == Gdk.KEY_Delete
-        if event.state & Gdk.ModifierType.SHIFT_MASK == Gdk.ModifierType.SHIFT_MASK \
-                and event.keyval == Gdk.KEY_ISO_Left_Tab: # Capure Shift-Tab
-            self.on_shift_tab()
-            return True
-        else:
-            return False
-
-    def on_shift_tab(self):
-        """Delete last character if it is a tab"""
-        text_buffer = self.get_buffer()
-        iter = text_buffer.get_end_iter()
-        end = text_buffer.get_end_iter()
-
-        iter.backward_char()
-
-        if iter.get_char() == "\t":
-            with user_action(text_buffer):
-	            text_buffer.delete(iter, end)
-
-
     def clear(self):
         """Clear text and undo history"""
 
@@ -302,3 +279,23 @@ class TextView(Gtk.TextView):
         """Returns the font width for a given size. Note: specific to Fira Mono!"""
 
         return font_size * 1 / 1.6
+
+    def _on_key_press_event(self, _widget, event):
+        if self.hemingway_mode:
+            return event.keyval == Gdk.KEY_BackSpace or event.keyval == Gdk.KEY_Delete
+
+        if event.state & Gdk.ModifierType.SHIFT_MASK == Gdk.ModifierType.SHIFT_MASK \
+                and event.keyval == Gdk.KEY_ISO_Left_Tab:  # Capure Shift-Tab
+            self._on_shift_tab()
+            return True
+
+    def _on_shift_tab(self):
+        """Delete last character if it is a tab"""
+        text_buffer = self.get_buffer()
+        pen_iter = text_buffer.get_end_iter()
+        pen_iter.backward_char()
+        end_iter = text_buffer.get_end_iter()
+
+        if pen_iter.get_char() == "\t":
+            with user_action(text_buffer):
+                text_buffer.delete(pen_iter, end_iter)

--- a/uberwriter/text_view.py
+++ b/uberwriter/text_view.py
@@ -246,8 +246,19 @@ class TextView(Gtk.TextView):
     def on_key_press_event(self, _widget, event):
         if self.hemingway_mode:
             return event.keyval == Gdk.KEY_BackSpace or event.keyval == Gdk.KEY_Delete
+        if event.state & Gdk.ModifierType.SHIFT_MASK == Gdk.ModifierType.SHIFT_MASK \
+                and event.keyval == Gdk.KEY_ISO_Left_Tab: # Capure Shift-Tab
+            self.on_shift_tab()
+            return True
         else:
             return False
+
+    def on_shift_tab(self):
+        """Delete last character if it is a tab"""
+
+        text = self.get_text()
+        if text[-1] == "\t":
+            self.set_text(text[:-1])
 
     def clear(self):
         """Clear text and undo history"""


### PR DESCRIPTION
Fixes #119 by removing the last character if it's `\t` when pressing Shift+Tab