### PR TITLE
Fix DnD for images, text and links

### DIFF
--- a/uberwriter/inline_preview.py
+++ b/uberwriter/inline_preview.py
@@ -191,10 +191,9 @@ class InlinePreview:
 
     def get_view_for_image(self, match):
         path = match.group("url")
-        if not path.startswith(("file://", "/")):
+        if not path.startswith(("/")):
             return self.get_view_for_link(match)
-        elif path.startswith("file://"):
-            path = path[7:]
+        path = unquote(path)
         return Gtk.Image.new_from_pixbuf(
             GdkPixbuf.Pixbuf.new_from_file_at_size(path, self.WIDTH, self.HEIGHT))
 

--- a/uberwriter/text_view_drag_drop_handler.py
+++ b/uberwriter/text_view_drag_drop_handler.py
@@ -1,5 +1,6 @@
 import mimetypes
 import urllib
+from gettext import gettext as _
 from os.path import basename
 
 from gi.repository import Gtk
@@ -26,6 +27,7 @@ class DragDropHandler:
         """Handle drag and drop events"""
 
         text_buffer = text_view.get_buffer()
+
         if info == TARGET_URI:
             uris = data.get_uris()
             for uri in uris:
@@ -33,28 +35,46 @@ class DragDropHandler:
                 mime = mimetypes.guess_type(uri)
 
                 if mime[0] is not None and mime[0].startswith('image/'):
+                    if uri.startswith("file://"):
+                        uri = uri[7:]
                     text = "![{}]({})".format(name, uri)
                     limit_left = 2
-                    limit_right = 23
+                    limit_right = len(name)
                 else:
                     text = "[{}]({})".format(name, uri)
                     limit_left = 1
-                    limit_right = 22
-                text_buffer.place_cursor(text_buffer.get_iter_at_mark(
-                    text_buffer.get_mark('gtk_drag_target')))
-                text_buffer.insert_at_cursor(text)
-                insert_mark = text_buffer.get_insert()
-                selection_bound = text_buffer.get_selection_bound()
-                cursor_iter = text_buffer.get_iter_at_mark(insert_mark)
-                cursor_iter.backward_chars(len(text) - limit_left)
-                text_buffer.move_mark(insert_mark, cursor_iter)
-                cursor_iter.forward_chars(limit_right)
-                text_buffer.move_mark(selection_bound, cursor_iter)
+                    limit_right = len(name)
 
         elif info == TARGET_TEXT:
-            text_buffer.place_cursor(text_buffer.get_iter_at_mark(
-                text_buffer.get_mark('gtk_drag_target')))
-            text_buffer.insert_at_cursor(data.get_text())
+            text = data.get_text()
+
+            # delete automatically added DnD text
+            insert_mark = text_buffer.get_insert()
+            cursor_iter_r = text_buffer.get_iter_at_mark(insert_mark)
+            cursor_iter_l = cursor_iter_r.copy()
+            cursor_iter_l.backward_chars(len(data.get_text()))
+
+            text_buffer.delete(cursor_iter_l, cursor_iter_r)
+
+            if text.startswith(("http://", "https://", "www.")):
+                print("web")
+                text = "[{}]({})".format(_("web page"), text)
+                limit_left = 1
+                limit_right = len(_("web page"))
+            else:
+                limit_left = 0
+                limit_right = 0
+
+        text_buffer.place_cursor(text_buffer.get_iter_at_mark(
+            text_buffer.get_mark('gtk_drag_target')))
+        text_buffer.insert_at_cursor(text)
+        insert_mark = text_buffer.get_insert()
+        selection_bound = text_buffer.get_selection_bound()
+        cursor_iter = text_buffer.get_iter_at_mark(insert_mark)
+        cursor_iter.backward_chars(len(text) - limit_left)
+        text_buffer.move_mark(insert_mark, cursor_iter)
+        cursor_iter.forward_chars(limit_right)
+        text_buffer.move_mark(selection_bound, cursor_iter)
 
         Gtk.drag_finish(drag_context, True, True, time)
         text_view.get_toplevel().present_with_time(time)


### PR DESCRIPTION
Fixes drag and drop:

- for images now we remove `file://` from the path so we don't break the output when exporting
- for text now we prevent pasting the text two times
- now we do some autoformatting for links
- and now we correctly leave selected text between brackets