### PR TITLE
Handle relative paths for images

### DIFF
--- a/uberwriter/inline_preview.py
+++ b/uberwriter/inline_preview.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 # END LICENSE
-
+import os
 import re
 import telnetlib
 from gettext import gettext as _
@@ -27,6 +27,10 @@ from gi.repository import Gtk, Gdk, GdkPixbuf, GLib
 from gi.repository import WebKit2
 from uberwriter import latex_to_PNG, markup_regex
 from uberwriter.settings import Settings
+
+import logging
+
+LOGGER = logging.getLogger('uberwriter')
 
 
 class DictAccessor:
@@ -191,8 +195,12 @@ class InlinePreview:
 
     def get_view_for_image(self, match):
         path = match.group("url")
-        if not path.startswith(("/")):
+        if path.startswith(("https://", "http://", "www.")):
             return self.get_view_for_link(match)
+        if path.startswith(("file://")):
+            path = path[7:]
+        if not path.startswith(("/", "file://")):
+            path = os.path.join(os.path.dirname(self.text_view.get_filepath()), path)
         path = unquote(path)
         return Gtk.Image.new_from_pixbuf(
             GdkPixbuf.Pixbuf.new_from_file_at_size(path, self.WIDTH, self.HEIGHT))

--- a/uberwriter/main_window.py
+++ b/uberwriter/main_window.py
@@ -70,6 +70,8 @@ class MainWindow(StyledWindow):
 
         self.get_style_context().add_class('uberwriter-window')
 
+        self.filename = None
+
         # Set UI
         builder = Gtk.Builder()
         builder.add_from_resource(
@@ -102,7 +104,7 @@ class MainWindow(StyledWindow):
         self.scrolled_window = builder.get_object('editor_scrolledwindow')
 
         # Setup text editor
-        self.text_view = TextView(self.settings.get_int("characters-per-line"))
+        self.text_view = TextView(self.settings.get_int("characters-per-line"), self.filename)
         self.text_view.connect('focus-out-event', self.focus_out)
         self.text_view.get_buffer().connect('changed', self.on_text_changed)
         self.text_view.show()
@@ -629,6 +631,7 @@ class MainWindow(StyledWindow):
         if filename:
             self.filename = filename
             base_path = os.path.dirname(self.filename)
+            self.text_view.set_filepath(os.path.join(os.getcwd(), filename))
         else:
             self.filename = None
             base_path = "/"

--- a/uberwriter/text_view.py
+++ b/uberwriter/text_view.py
@@ -44,8 +44,10 @@ class TextView(Gtk.TextView):
 
     font_sizes = [18, 17, 16, 15, 14]  # Must match CSS selectors in gtk/base.css
 
-    def __init__(self, line_chars):
+    def __init__(self, line_chars, filepath=None):
         super().__init__()
+        # Store the filename of the edited file
+        self.set_filepath(filepath)
 
         # Appearance
         self.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
@@ -299,3 +301,10 @@ class TextView(Gtk.TextView):
         if pen_iter.get_char() == "\t":
             with user_action(text_buffer):
                 text_buffer.delete(pen_iter, end_iter)
+
+    def set_filepath(self, filepath):
+        """Change the file edited by this TextView"""
+        self.filepath = filepath
+
+    def get_filepath(self):
+        return self.filepath


### PR DESCRIPTION
Currently, images are correctly shown in the inline preview by replacing the relative paths with an absolute path when loading the image.

It doesn't work in the preview or in the exported files yet.