### PR TITLE
Fix regex for horizontal rules

### DIFF
--- a/uberwriter/markup_regex.py
+++ b/uberwriter/markup_regex.py
@@ -19,7 +19,7 @@ LINK_ALT = re.compile(
 IMAGE = re.compile(
     r"!\[(?P<text>.*)\]\((?P<url>.+?)(?: \"(?P<title>.+)\")?\)")
 HORIZONTAL_RULE = re.compile(
-    r"(?:^|\n)(?P<symbols> {0,3}[*\-_]{3,} *)(?:\n+|$)")
+    r"(?:\n\n)(?P<symbols> {0,3}[*\-_]{3,} *)(?:\n\n+)")
 LIST = re.compile(
     r"(?:^|\n)(?P<content>(?P<indent>(?:\t| {4})*)[\-*+]( +)(?P<text>.+(?:\n+ \2.+)*))")
 ORDERED_LIST = re.compile(

--- a/uberwriter/markup_regex.py
+++ b/uberwriter/markup_regex.py
@@ -19,7 +19,7 @@ LINK_ALT = re.compile(
 IMAGE = re.compile(
     r"!\[(?P<text>.*)\]\((?P<url>.+?)(?: \"(?P<title>.+)\")?\)")
 HORIZONTAL_RULE = re.compile(
-    r"(?:\n\n)(?P<symbols> {0,3}[*\-_]{3,} *)(?:\n\n+)")
+    r"(?:^|\n{2,})(?P<symbols> {0,3}[*\-_]{3,} *)(?:\n{2,}|$)")
 LIST = re.compile(
     r"(?:^|\n)(?P<content>(?P<indent>(?:\t| {4})*)[\-*+]( +)(?P<text>.+(?:\n+ \2.+)*))")
 ORDERED_LIST = re.compile(


### PR DESCRIPTION
Fix regex for horizontal rules
(yaml metadata delimiters should not be counted as rules)