### PR TITLE
Handle local paths

### DIFF
--- a/data/lua/relative_to_absolute.lua
+++ b/data/lua/relative_to_absolute.lua
@@ -6,7 +6,7 @@ function fix_path (path)
   if string.starts(path, "/") then
     return path
   else
-    return (os.getenv('PANDOC_PREFIX') or '') .. path
+    return (pandoc.system.get_working_directory() or '') .. "/" .. path
   end
 end
 

--- a/uberwriter/export_dialog.py
+++ b/uberwriter/export_dialog.py
@@ -238,7 +238,7 @@ class Export:
 
             if export_type == "html":
                 to = "html5"
-                args.append("--standalone")
+                args.append("--self-contained")
                 args.append("--css=%s" % Theme.get_current().web_css_path)
                 args.append("--mathjax")
                 args.append("--lua-filter=%s" % helpers.get_script_path('relative_to_absolute.lua'))

--- a/uberwriter/main_window.py
+++ b/uberwriter/main_window.py
@@ -442,7 +442,6 @@ class MainWindow(StyledWindow):
             return
 
         if filename:
-            print(urllib.parse.unquote(filename))
             if filename.startswith('file://'):
                 filename = urllib.parse.unquote(filename)[7:]
             self.text_view.clear()
@@ -520,7 +519,6 @@ class MainWindow(StyledWindow):
     def open_recent(self, _widget, data=None):
         """open the given recent document
         """
-        print("open")
 
         if data:
             if self.check_change() == Gtk.ResponseType.CANCEL:
@@ -631,6 +629,7 @@ class MainWindow(StyledWindow):
         if filename:
             self.filename = filename
             base_path = os.path.dirname(self.filename)
+            os.chdir(base_path)
         else:
             self.filename = None
             base_path = "/"

--- a/uberwriter/text_view_drag_drop_handler.py
+++ b/uberwriter/text_view_drag_drop_handler.py
@@ -57,7 +57,6 @@ class DragDropHandler:
             text_buffer.delete(cursor_iter_l, cursor_iter_r)
 
             if text.startswith(("http://", "https://", "www.")):
-                print("web")
                 text = "[{}]({})".format(_("web page"), text)
                 limit_left = 1
                 limit_right = len(_("web page"))


### PR DESCRIPTION
This PR allows uberwriter to handle seamlessly local paths in links and images, both in the inline preview, the live preview and the output